### PR TITLE
made this compatible with windows

### DIFF
--- a/pyls_jsonrpc/streams.py
+++ b/pyls_jsonrpc/streams.py
@@ -25,6 +25,10 @@ class JsonRpcStreamReader(object):
 
             if request_str is None:
                 break
+                
+            # to check for windows line endings    
+            if request_str == '\r\n':
+                break
 
             try:
                 message_consumer(json.loads(request_str.decode('utf-8')))


### PR DESCRIPTION
I was messing around with the pyls source code and I kept getting an error. Stepped through it with a debugger and realized that this line of code doesn't account for windows line endings. I fixed it so now it does work