### PR TITLE
Don't throw if rfile is closed

### DIFF
--- a/pyls_jsonrpc/streams.py
+++ b/pyls_jsonrpc/streams.py
@@ -22,7 +22,13 @@ class JsonRpcStreamReader(object):
             message_consumer (fn): function that is passed each message as it is read off the socket.
         """
         while not self._rfile.closed:
-            request_str = self._read_message()
+            try:
+              request_str = self._read_message()
+            except ValueError:
+              if self._rfile.closed:
+                return
+              else:
+                log.exception("Failed to read from rfile")
 
             if request_str is None:
                 break

--- a/pyls_jsonrpc/streams.py
+++ b/pyls_jsonrpc/streams.py
@@ -23,12 +23,12 @@ class JsonRpcStreamReader(object):
         """
         while not self._rfile.closed:
             try:
-              request_str = self._read_message()
+                request_str = self._read_message()
             except ValueError:
-              if self._rfile.closed:
-                return
-              else:
-                log.exception("Failed to read from rfile")
+                if self._rfile.closed:
+                    return
+                else:
+                    log.exception("Failed to read from rfile")
 
             if request_str is None:
                 break


### PR DESCRIPTION
Ideally listen() should exit gracefully when the stream is closed. The current loop condition isn't enough to ensure that though, because most of the time listen() will be blocked on self._rfile.readline().