### PR TITLE
Set parentdir_prefix in setup.py to fix egg version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ style = pep440
 versionfile_source = pyls_jsonrpc/_version.py
 versionfile_build = pyls_jsonrpc/_version.py
 tag_prefix =
-parentdir_prefix =
+parentdir_prefix = python-jsonrpc-server-
 
 [pycodestyle]
 ignore = E226, E722, W504


### PR DESCRIPTION
Hello, when trying to install this from the latest version tarball, I ran into an issue where versioneer couldn't figure out the correct version (and thus set it to 0+unknown).

This make the pyls project unable to find it.

I'm unsure if this is the correct way to go about fixing this issue. But it seems work for me.