### PR TITLE
Remove future dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'future>=0.14.0; python_version<"3"',
         'futures; python_version<"3.2"',
         'ujson<=1.35; platform_system!="Windows"',
     ],


### PR DESCRIPTION
It doesn't seem like there's any use of the `future` package in this project, so, I think it can be safely removed... 

Besides inspecting the source code, I was able to run all the tests locally without it being installed.

Note that the tests still end up installing it due to some of its deps -- one of: `versioneer`, `pylint`, `pycodestyle` or `pyflakes` end up using it (but I didn't really bother finding out which -- it doesn't seem like those are used either when testing... maybe they can be removed too?)