### PR TITLE
Replace logging.Logger.warn method for logging.Logger.warning

### DIFF
--- a/pyls_jsonrpc/endpoint.py
+++ b/pyls_jsonrpc/endpoint.py
@@ -98,7 +98,7 @@ class Endpoint(object):
             message (dict): The JSON RPC message sent by the client
         """
         if 'jsonrpc' not in message or message['jsonrpc'] != JSONRPC_VERSION:
-            log.warn("Unknown message type %s", message)
+            log.warning("Unknown message type %s", message)
             return
 
         if 'id' not in message:
@@ -135,7 +135,7 @@ class Endpoint(object):
         try:
             handler = self._dispatcher[method]
         except KeyError:
-            log.warn("Ignoring notification for unknown method %s", method)
+            log.warning("Ignoring notification for unknown method %s", method)
             return
 
         try:
@@ -165,7 +165,7 @@ class Endpoint(object):
         request_future = self._client_request_futures.pop(msg_id, None)
 
         if not request_future:
-            log.warn("Received cancel notification for unknown message id %s", msg_id)
+            log.warning("Received cancel notification for unknown message id %s", msg_id)
             return
 
         # Will only work if the request hasn't started executing
@@ -230,7 +230,7 @@ class Endpoint(object):
         request_future = self._server_request_futures.pop(msg_id, None)
 
         if not request_future:
-            log.warn("Received response to unknown message id %s", msg_id)
+            log.warning("Received response to unknown message id %s", msg_id)
             return
 
         if error is not None:


### PR DESCRIPTION
Just so that the test suite doesn’t spew unnecessary warnings.