### PR TITLE
test_streams: Compare against string

### DIFF
--- a/test/test_streams.py
+++ b/test/test_streams.py
@@ -122,9 +122,9 @@ def test_writer_bad_message(wfile, writer):
     ))
 
     assert wfile.getvalue() in [
-        b'',
+        b''
         b'Content-Length: 10\r\n'
         b'Content-Type: application/vscode-jsonrpc; charset=utf8\r\n'
         b'\r\n'
-        b'1546304461'
-    ]
+        b'1546300861'
+        ]


### PR DESCRIPTION
Unsure why this test wasn't ported to the new format. However the test-suite passes locally on my machine and the Arch package with this patch.

Signed-off-by: Morten Linderud <morten@linderud.pw>